### PR TITLE
update README, added error info and prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ AndroRAT requires Python (> 3.6) and JAVA 8 (or Android Studio)
 git clone https://github.com/karma9874/AndroRAT.git
 pip install colorama
 ```
+#### Note: 
+While cloning the repository using Git bash on windows, you may get the following error:
+> error: unable to create file \<filename>: Filename too long
+
+This is because the Git has a limit of 4096 characters for a filename, except on Windows when Git is compiled with msys. It uses an older version of the Windows API and there's a limit of 260 characters for a filename. 
+
+You can circumvent this by setting `core.longpaths` to `true`.
+
+> git config -system core.longpaths true
+
+You must run Git bash with administrator privileges. 
+
+
+
+
 ## Usage (Windows and Linux)
 ### Available Modes
 * `--build` - for building the android apk 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ You can circumvent this by setting `core.longpaths` to `true`.
 
 You must run Git bash with administrator privileges. 
 
-
-
-
 ## Usage (Windows and Linux)
 ### Available Modes
 * `--build` - for building the android apk 


### PR DESCRIPTION
Windows Git bash users may face the error of filename too long. This PR updates the README with useful information regarding the error and recovery. 